### PR TITLE
Decode entities in the URL

### DIFF
--- a/Classes/Data/Story.m
+++ b/Classes/Data/Story.m
@@ -46,7 +46,7 @@ NSMutableDictionary *storyDictionary;
 	aStory.domain = (NSString *)[dict objectForKey:@"domain"];
 	aStory.identifier = (NSString *)[dict objectForKey:@"id"];
 	aStory.name = (NSString *)[dict objectForKey:@"name"];
-	aStory.URL = (NSString *)[dict objectForKey:@"url"];
+	aStory.URL = [(NSString *)[dict objectForKey:@"url"] stringByDecodingHTMLEncodedCharacters];
 	aStory.created = (NSString *)[(NSNumber *)[dict objectForKey:@"created_utc"] stringValue];
 	aStory.kind = @"t3";
 	aStory.thumbnailURL = (NSString *)[dict objectForKey:@"thumbnail"];


### PR DESCRIPTION
Currently, HTML entities in the URL are not decoded, leading to ampersands not being decoded in the URL.

This can be reproduced by accessing the current link on http://www.reddit.com/r/rmccuetest via both the web and via iReddit. In iReddit, the URL is shown to have `&amp;` instead of `&`.

This commit fixes it. (And only includes the one commit, unlike the other request)
