### PR TITLE
Fix for open issue #13 - "Shake for new story" Bug

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "TouchJSON"]
 	path = TouchJSON
-	url = https://github.com/schwa/TouchJSON.git
+	url = https://github.com/TouchCode/TouchJSON.git
 [submodule "three20"]
 	path = three20
 	url = https://github.com/facebook/three20.git

--- a/Classes/iRedditAppDelegate.h
+++ b/Classes/iRedditAppDelegate.h
@@ -30,6 +30,7 @@
 + (UIColor *)redditNavigationBarTintColor;
 + (iRedditAppDelegate *)sharedAppDelegate;
 
+- (void)loadRandomData;
 - (void)reloadSound;
 - (void)showRandomStory;
 

--- a/Classes/iRedditAppDelegate.m
+++ b/Classes/iRedditAppDelegate.m
@@ -85,6 +85,11 @@ iRedditAppDelegate *sharedAppDelegate;
     [self loadRandomData];
 }
 
+- (void)applicationWillResignActive:(UIApplication *)application
+{
+	shouldDetectDeviceShake = NO;
+}
+
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
 #ifdef DEPRECATED_FREE
@@ -102,6 +107,7 @@ iRedditAppDelegate *sharedAppDelegate;
         [deprecatedAlert release];
     }
 #endif
+    shouldDetectDeviceShake = YES;
 }
 
 - (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex


### PR DESCRIPTION
Uses already-existing variable shouldDetectDeviceShake to disable "shake for new story" when the device is locked.  It is enabled again when the device is unlocked.

Previously, movement of the device when locked would load multiple new stories.  See issue #13 for more info.

Also added a declaration for (void)loadRandomData; to the header file, to remove a compiler warning.
